### PR TITLE
[minor] => add namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    namespace "com.amorenew.c72.uhf_plugin"
 }
 
 dependencies {


### PR DESCRIPTION
Gradle 8+ required every module to add [namespace](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl) in build.gradle file. Otherwise the project won't run at all. So i forked and added one. 

Tested and worked with my C72 device.